### PR TITLE
fix: Show README.md on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "schematools"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "Inflector",
  "digest 0.10.1",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "schematools-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/crates/schematools/Cargo.toml
+++ b/crates/schematools/Cargo.toml
@@ -3,6 +3,7 @@ name = "schematools"
 description = "Tools for codegen, preprocessing and validation of json-schema and openapi spec"
 edition = "2018"
 license.workspace = true
+readme = "../../README.md"
 repository.workspace = true
 version.workspace = true
 


### PR DESCRIPTION
This goes with the common approach I have seen work.

[`readme.workspace = true`](https://github.com/search?q=readme.workspace+%3D+true&type=code) may work - but I am not sure. e.g. https://crates.io/crates/meilisearch & https://crates.io/crates/crane & https://crates.io/crates/yara-x-parser are not showing it.