### PR TITLE
feat: nested string enum support

### DIFF
--- a/crates/cli/src/commands/chain.rs
+++ b/crates/cli/src/commands/chain.rs
@@ -156,11 +156,10 @@ pub fn execute(opts: Opts, client: &Client) -> Result<(), Error> {
             match cmd {
                 #[cfg(feature = "codegen")]
                 ChainCommandOption::Codegen(c) => c.run(current, &discovery, &storage),
-                ChainCommandOption::Process(c) => c.run(current, &storage).map(|result| {
+                ChainCommandOption::Process(c) => c.run(current, &storage).inspect(|_| {
                     storage
                         .schemas
                         .insert(current.get_url().clone(), current.clone());
-                    result
                 }),
                 ChainCommandOption::Validate(v) => v.run(current),
                 ChainCommandOption::Output(o) => {

--- a/crates/cli/src/commands/validate.rs
+++ b/crates/cli/src/commands/validate.rs
@@ -84,10 +84,7 @@ impl Opts {
                 validate::validate_jsonschema(schema).map_err(Error::Schematools)
             }
         }
-        .map(|r| {
-            log::info!("\x1b[0;32mSuccessful validation!\x1b[0m");
-            r
-        })
+        .inspect(|_| log::info!("\x1b[0;32mSuccessful validation!\x1b[0m"))
         .or_else(|e| {
             log::error!("\x1b[1;31mValidation failed: \x1b[0m {}", e);
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,7 +6,6 @@ pub mod error;
 
 #[derive(Parser)]
 #[command(author, version, about)]
-
 struct Opts {
     #[clap(subcommand)]
     command: Command,

--- a/crates/schematools/src/codegen/jsonschema/mod.rs
+++ b/crates/schematools/src/codegen/jsonschema/mod.rs
@@ -233,10 +233,7 @@ pub fn extract_type(
 
         match node {
             Value::Object(schema) => {
-                title::extract_title(schema, scope, options).map(|s| {
-                    scope.entity(&s);
-                    s
-                })?;
+                title::extract_title(schema, scope, options).inspect(|s| scope.entity(s))?;
 
                 log::trace!("{}", scope);
 

--- a/crates/schematools/src/codegen/jsonschema/oneof/mod.rs
+++ b/crates/schematools/src/codegen/jsonschema/oneof/mod.rs
@@ -291,7 +291,7 @@ mod tests {
                                 "_discriminator".to_string(),
                                 json!({
                                     "property": "type",
-                                    "value": {"model": "value1"},
+                                    "value": {"model":{"name": "value1","kind":"string"}},
                                     "properties": 1
                                 })
                             )]
@@ -317,7 +317,7 @@ mod tests {
                                 "_discriminator".to_string(),
                                 json!({
                                     "property": "type",
-                                    "value": {"model":"value2"},
+                                    "value": {"model":{"name": "value2","kind":"string"}},
                                     "properties": 1
                                 })
                             )]

--- a/crates/schematools/src/codegen/jsonschema/properties.rs
+++ b/crates/schematools/src/codegen/jsonschema/properties.rs
@@ -30,10 +30,7 @@ pub fn from_object_with_properties(
                     let mut model =
                         super::extract_type(property, container, scope, resolver, options)
                             .and_then(|s| s.flatten(container, scope))
-                            .map_err(|e| {
-                                scope.pop();
-                                e
-                            })?;
+                            .inspect_err(|_| scope.pop())?;
 
                     model.name = Some(name.clone());
                     model.attributes.required = required.contains(name);
@@ -42,12 +39,8 @@ pub fn from_object_with_properties(
                         && !model.attributes.required
                         && options.optional_and_nullable_as_models
                     {
-                        convert_to_nullable_optional_wrapper(model, container, scope).map_err(
-                            |e| {
-                                scope.pop();
-                                e
-                            },
-                        )?
+                        convert_to_nullable_optional_wrapper(model, container, scope)
+                            .inspect_err(|_| scope.pop())?
                     } else {
                         model
                     };

--- a/crates/schematools/src/tools.rs
+++ b/crates/schematools/src/tools.rs
@@ -156,7 +156,7 @@ impl<'a> ArgumentsExtractor<'a> {
     }
 }
 
-impl<'a> Iterator for ArgumentsExtractor<'a> {
+impl Iterator for ArgumentsExtractor<'_> {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
When `oneOf` wrapper is created it incorrectly interprets an enum string variant. On a template level we have to somehow detect that an enum variant points to a string enum.