### PR TITLE
Feature/multiple responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "schematools"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "Inflector",
  "digest",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "schematools-cli"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "clap",
  "env_logger",

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![build](https://github.com/kstasik/schema-tools/workflows/build/badge.svg)](https://github.com/kstasik/schema-tools/actions)
 [![tests](https://github.com/kstasik/schema-tools/workflows/test/badge.svg)](https://github.com/kstasik/schema-tools/actions)
+[![crates-cli](https://img.shields.io/crates/v/schematools-cli)](https://crates.io/crates/schematools-cli)
+[![crates-lib](https://img.shields.io/crates/v/schematools)](https://crates.io/crates/schematools)
 
 # Introduction
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,49 @@ Main differences in approach between other solutions like `openapi-generator`:
 - codegen executed per microservice approach (not as a separate, generic client library)
 - json-schema registry support, TODO: shared models - create one model for shared structures in different clients/servers to avoid mapping same structures
 
+# Examples
+
+Install `CLI` tool:
+
+```
+cargo install schematools-cli@0.21.0
+```
+
+## json-schema struct codegen
+
+```
+schematools-cli chain -vvv -c 'registry add templates https://github.com/kstasik/schema-tools-templates --rev 411f5207001637c19380046a21991b9ddba2bfe9' \
+   -c 'process dereference https://raw.githubusercontent.com/kstasik/schema-tools/refs/heads/master/crates/schematools/resources/test/json-schemas/01-simple.json --skip-root-internal-references --create-internal-references' \
+   -c 'process merge-all-of - --leave-invalid-properties' \
+   -c 'codegen json-schema - --base-name Person --template templates::rust/_common/ --template templates::rust/model/ --format "rustfmt --edition 2021" --target-dir schemas/ -o namespace=people -o skipValidate=~true'
+```
+
+## openapi client codegen
+
+```
+schematools-cli \
+   chain -vvv -c 'registry add templates https://github.com/kstasik/schema-tools-templates --rev 411f5207001637c19380046a21991b9ddba2bfe9' \
+   -c 'process dereference https://raw.githubusercontent.com/kstasik/schema-tools/refs/heads/master/crates/schematools/resources/test/openapi/01-simple.yaml --skip-root-internal-references --create-internal-references' \
+   -c 'process merge-all-of - --leave-invalid-properties' \
+   -c 'codegen openapi - --template templates::rust/_common/ --template templates::rust/client/ --format "rustfmt --edition 2021" --target-dir src/clients/ -o apm=tracing -o name=simple -o namespace=simple -o skipValidate=~true'
+```
+
+## debugging json processing stages
+
+You can use the `output` command multiple times to inspect how the JSON/YAML file appears at different stages of the process.
+
+```
+   -c 'output --to-file formatted.json -o json"' \
+```
+
+## using local templates / overwriting original templates
+
+Create a `local-templates` directory and link it as the last used directory. Maintain the original registry naming if you wish to overwrite the templates.
+
+```
+   --template templates::rust/_common/ --template templates::rust/client/ --template local-templates/
+```
+
 # General rules
 
 - All commands support yaml and json files.

--- a/crates/schematools/resources/test/openapi/01-simple.yaml
+++ b/crates/schematools/resources/test/openapi/01-simple.yaml
@@ -1,15 +1,16 @@
-requestBodies:
-  requestbody1:
-    content:
-      application/json:
-        schema:
-          required:
-            - items
-          type: object
-          properties:
-            items:
-              type: string
-    required: true
+components:
+  requestBodies:
+    requestBody1:
+      content:
+        application/json:
+          schema:
+            required:
+              - items
+            type: object
+            properties:
+              items:
+                type: string
+      required: true
   responses:
     response1:
       content:

--- a/crates/schematools/src/codegen/jsonschema/types.rs
+++ b/crates/schematools/src/codegen/jsonschema/types.rs
@@ -398,7 +398,7 @@ impl Model {
                 p.name = Some(name);
                 ModelType::ArrayType(p)
             }
-            _ => panic!("Unsupported rename: {}", name),
+            _ => panic!("Unsupported rename: {name}"),
         })
     }
 }

--- a/crates/schematools/src/codegen/openapi/mod.rs
+++ b/crates/schematools/src/codegen/openapi/mod.rs
@@ -90,16 +90,18 @@ impl Serialize for MediaModelsContainer {
                     .find(|m| m.content_type == self.default_content_type);
                 let with_names: Vec<_> = models.iter().collect();
 
-                let mut map = serializer.serialize_map(Some(2))?;
+                let mut map = serializer.serialize_map(Some(3))?;
 
                 map.serialize_entry("default", &default)?;
                 map.serialize_entry("all", &with_names)?; // map models and add something to detect vnd types?
+                map.serialize_entry("multipleContentTypes", &self.multiple_content_types)?;
                 map.end()
             }
             std::cmp::Ordering::Equal => {
-                let mut map = serializer.serialize_map(Some(2))?;
+                let mut map = serializer.serialize_map(Some(3))?;
                 map.serialize_entry("default", models.first().unwrap())?;
                 map.serialize_entry("all", &models)?;
+                map.serialize_entry("multipleContentTypes", &self.multiple_content_types)?;
                 map.end()
             }
             std::cmp::Ordering::Less => serializer.serialize_none(),

--- a/crates/schematools/src/codegen/openapi/mod.rs
+++ b/crates/schematools/src/codegen/openapi/mod.rs
@@ -39,9 +39,18 @@ impl EndpointContainer {
 pub struct MediaModel {
     pub model: crate::codegen::jsonschema::types::FlatModel,
 
+    /// preferred is application/json
     pub content_type: String,
 
+    /// Indicates whether the model is unique to the endpoint. 
+    /// If it is, the model can be directly converted to the appropriate response using From<Model>
+    /// 
+    /// Uniqness is checked on endpoint level, all models for an endpoints are scanned.
     pub is_unique: bool,
+
+    /// Available if an endpoint returns multiple content types and it's not an alternative vendor type
+    /// Preferred content-type is application/json and all other types are treated as alternative
+    pub alternative_content_type: Option<String>
 }
 
 #[derive(Debug, Clone)]
@@ -298,6 +307,7 @@ pub fn get_content(
                                             model,
                                             content_type: content_type.to_string(),
                                             is_unique: false,
+                                            alternative_content_type: None
                                         }),
                                 );
 

--- a/crates/schematools/src/codegen/openapi/responses.rs
+++ b/crates/schematools/src/codegen/openapi/responses.rs
@@ -100,17 +100,17 @@ pub fn extract_responses(
                 }
             }
 
+            let re = regex::Regex::new(r"/vnd\.|\+").unwrap();
             for response in parsed.iter_mut() {
                 if let Some(ref mut mcontainer) = response.models {
                     // inidicates if an endpoint has multiple content types
-                    mcontainer.multiple_content_types = mcontainer.list.len() > 0;
+                    mcontainer.multiple_content_types = mcontainer.list.len() > 1;
 
                     for mm in mcontainer.list.iter_mut() {
                         let key: String = (&mm.model).into();
 
                         mm.is_unique = *occurrences.get(&key).unwrap_or(&1) == 1;
 
-                        let re = regex::Regex::new(r"/vnd\.|\+").unwrap();
                         let mut base_content_type = mm.content_type.clone();
                         if let [b, inner, e] = re.split(&mm.content_type).collect::<Vec<_>>()[..] {
                             base_content_type = format!("{}/{}", b, e);

--- a/crates/schematools/src/codegen/openapi/responses.rs
+++ b/crates/schematools/src/codegen/openapi/responses.rs
@@ -113,7 +113,7 @@ pub fn extract_responses(
 
                         let mut base_content_type = mm.content_type.clone();
                         if let [b, inner, e] = re.split(&mm.content_type).collect::<Vec<_>>()[..] {
-                            base_content_type = format!("{}/{}", b, e);
+                            base_content_type = format!("{b}/{e}");
                             mm.vnd = Some(MediaVendorType {
                                 base: base_content_type.clone(),
                                 vnd: inner.to_string(),

--- a/crates/schematools/src/tools.rs
+++ b/crates/schematools/src/tools.rs
@@ -69,7 +69,7 @@ where
                     }
                 }
             } else {
-                panic!("Incorrect path: {}", search);
+                panic!("Incorrect path: {search}");
             }
         }
     }
@@ -138,7 +138,7 @@ where
                     }
                 }
             } else {
-                panic!("Incorrect path: {}", search);
+                panic!("Incorrect path: {search}");
             }
         }
     }
@@ -336,7 +336,7 @@ impl Display for ConditionOperator {
         }
         .to_string();
 
-        write!(f, "{}", str)
+        write!(f, "{str}")
     }
 }
 


### PR DESCRIPTION
Additional variables for multiple response types support and alternative media types if more than one is provided in api spec. README updated.

Alternative media types is more useful for the client generator.
Multiple response types may be used on the server generator to check if "Accept" header support is needed.