### PR TITLE
Feature/skip endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "schematools"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "Inflector",
  "digest",
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "schematools-cli"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "clap",
  "env_logger",

--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ schema-tools codegen openapi openapi.json --template templates/  --target-dir pk
 - `--nested-arrays-as-models` - some languages allow to create `Vec<HashMap<Vec<HashMap>>>>` / `[][][]int` inline types, some may need to create wrapping types for such cases
 - `--optional-and-nullable-as-models` - openapi allows to create two levels of "nullability", some languages doesnt distinguish between null and undefined. This option wrap all occurrences of nullable and optional fields in separate types
 - `--wrappers` - option to wrap mixed types (oneOf) to custom objects with custom deserialization logic
+- `--skip-endpoint <operation-id>` - skip an endpoint by `operationId`. Can be repeated. Models referenced only by skipped endpoints are removed from the output.
+- `--only-endpoint <operation-id>` - keep only the endpoints with given `operationId`. Can be repeated. All other endpoints and their unique models are removed.
+- `--skip-unused-models` - remove models that are not referenced by any kept endpoint.
+- `--keep-schema <path>` - keep the original JSON schema in selected nodes so it is available in templates. Can be repeated.
 - `-o <options>` - option to pass options (string or json) to all templates files ex. `-o 'name=ordersClient' -o 'usedEndpoints=["/orders", "/orders/{id}/items"]'`
 - `--format` - executes language formatter after code generation ex. `--format "gofmt -w"`
 

--- a/README.md
+++ b/README.md
@@ -155,13 +155,13 @@ It's useful to perform such thing before code generation taking into account tha
 If openapi you received seems broken you may fix it and create [json-patch](http://jsonpatch.com/) file:
 
 ```
-schematools process patch <file> create <original-file> 
+schematools process patch <file> create <original-file>
 ```
 
 Then you can apply such patch to original openapi file during processing:
 
 ```
-schematools process patch <file> apply <patch-file> 
+schematools process patch <file> apply <patch-file>
 ```
 
 ### Merge openapi and bump
@@ -213,6 +213,7 @@ schema-tools codegen openapi openapi.json --template templates/  --target-dir pk
 - `--only-endpoint <operation-id>` - keep only the endpoints with given `operationId`. Can be repeated. All other endpoints and their unique models are removed.
 - `--skip-unused-models` - remove models that are not referenced by any kept endpoint.
 - `--keep-schema <path>` - keep the original JSON schema in selected nodes so it is available in templates. Can be repeated.
+- `--merge-similar-models` - merge models with identical structure ignoring `title` and `description`.
 - `-o <options>` - option to pass options (string or json) to all templates files ex. `-o 'name=ordersClient' -o 'usedEndpoints=["/orders", "/orders/{id}/items"]'`
 - `--format` - executes language formatter after code generation ex. `--format "gofmt -w"`
 
@@ -287,7 +288,7 @@ All commands take same arguments as they were executed separately. The only diff
 schematools chain -vvvv \
    -c 'process merge-all-of --leave-invalid-properties specifications/api.yaml' \
    -c 'process name - --resource-method-version --overwrite' \
-   -c 'validate openapi - ' 
+   -c 'validate openapi - '
    -c 'codegen openapi - \
         --template codegen/server/ \
         --format "gofmt -w" \

--- a/crates/cli/src/commands/codegen.rs
+++ b/crates/cli/src/commands/codegen.rs
@@ -104,6 +104,20 @@ pub struct OpenapiOpts {
     #[clap(long, required = false)]
     keep_schema: Vec<String>,
 
+    /// Operation id of an endpoint to skip. Can be repeated. Models referenced only by skipped
+    /// endpoints are also removed from the generated output.
+    #[clap(long = "skip-endpoint", required = false)]
+    skip_endpoint: Vec<String>,
+
+    /// Keep only these operation ids. All other endpoints and their unique models are removed.
+    /// Can be repeated.
+    #[clap(long = "only-endpoint", required = false)]
+    only_endpoint: Vec<String>,
+
+    /// Remove models that are not referenced by any kept endpoint.
+    #[clap(long, required = false)]
+    skip_unused_models: bool,
+
     /// Directory with templates, name:: prefix if pointing to registry
     #[clap(long, required = true)]
     template: Vec<String>,
@@ -204,6 +218,9 @@ impl Opts {
                         optional_and_nullable_as_models: opts.optional_and_nullable_as_models,
                         nested_arrays_as_models: opts.nested_arrays_as_models,
                         keep_schema: schematools::tools::Filter::new(&opts.keep_schema)?,
+                        skip_endpoints: opts.skip_endpoint.clone(),
+                        only_endpoints: opts.only_endpoint.clone(),
+                        skip_unused_models: opts.skip_unused_models,
                     },
                 )?;
 

--- a/crates/cli/src/commands/codegen.rs
+++ b/crates/cli/src/commands/codegen.rs
@@ -64,6 +64,10 @@ pub struct JsonSchemaOpts {
     #[clap(long)]
     pub base_name: Option<String>,
 
+    /// Merge models with the same structure ignoring title and description
+    #[clap(long)]
+    pub merge_similar_models: bool,
+
     /// Directory with templates, name:: prefix if pointing to registry
     #[clap(long, required = true)]
     template: Vec<String>,
@@ -99,6 +103,10 @@ pub struct OpenapiOpts {
     /// Treat nested arrays as models
     #[clap(long)]
     pub nested_arrays_as_models: bool,
+
+    /// Merge models with the same structure ignoring title and description
+    #[clap(long)]
+    pub merge_similar_models: bool,
 
     /// Keep schema condition (allows access to original json schema in selected nodes)
     #[clap(long, required = false)]
@@ -178,6 +186,7 @@ impl Opts {
                         optional_and_nullable_as_models: opts.optional_and_nullable_as_models,
                         nested_arrays_as_models: opts.nested_arrays_as_models,
                         base_name: opts.base_name.clone(),
+                        merge_similar_models: opts.merge_similar_models,
                         allow_list: true,
                         keep_schema: schematools::tools::Filter::new(&opts.keep_schema)?,
                     },
@@ -217,6 +226,7 @@ impl Opts {
                         wrappers: opts.wrappers,
                         optional_and_nullable_as_models: opts.optional_and_nullable_as_models,
                         nested_arrays_as_models: opts.nested_arrays_as_models,
+                        merge_similar_models: opts.merge_similar_models,
                         keep_schema: schematools::tools::Filter::new(&opts.keep_schema)?,
                         skip_endpoints: opts.skip_endpoint.clone(),
                         only_endpoints: opts.only_endpoint.clone(),

--- a/crates/schematools/resources/test/openapi/04-codegen-dedup.yaml
+++ b/crates/schematools/resources/test/openapi/04-codegen-dedup.yaml
@@ -1,0 +1,81 @@
+openapi: 3.1.0
+info:
+  title: CodegenDedupApi
+  description: codegen dedup test
+  version: 0.1.0
+
+components:
+  parameters:
+    pathId:
+      name: id
+      in: path
+      description: Resource id
+      schema:
+        type: string
+    page:
+      name: page
+      in: query
+      description: Page number
+      schema:
+        type: integer
+        default: 1
+        minimum: 1
+  schemas:
+    ResourceList:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceDefinition'
+    ResourceDefinition2:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    ResourceDefinition:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+
+paths:
+  /v2/resources/{id}:
+    get:
+      description: Some description
+      operationId: resourceGet
+      parameters:
+        - $ref: '#/components/parameters/pathId'
+        - $ref: '#/components/parameters/page'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceList'
+  /v2/resources2/{id}:
+    get:
+      description: Some description 2
+      operationId: resourceGet2
+      parameters:
+        - $ref: '#/components/parameters/pathId'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceDefinition2'

--- a/crates/schematools/src/codegen/filters.rs
+++ b/crates/schematools/src/codegen/filters.rs
@@ -98,10 +98,7 @@ pub fn register(tera: &mut Tera) {
         "get_bucket_count",
         bucket_counter::get_bucket_count(counter.clone()),
     );
-    tera.register_function(
-        "clear_bucket",
-        bucket_counter::clear_bucket(counter.clone()),
-    );
+    tera.register_function("clear_bucket", bucket_counter::clear_bucket(counter));
 }
 
 pub fn pascalcase(value: &Value, _: &HashMap<String, Value>) -> TeraResult<Value> {

--- a/crates/schematools/src/codegen/jsonschema/anyoneof/mod.rs
+++ b/crates/schematools/src/codegen/jsonschema/anyoneof/mod.rs
@@ -146,6 +146,7 @@ fn simplify_one_or_any_of(
                             node.as_object().unwrap(),
                             container,
                             options.keep_schema.check(node, false),
+                            options.merge_similar_models,
                         )
                         .with_attributes(&attributes)))
                     })

--- a/crates/schematools/src/codegen/jsonschema/mod.rs
+++ b/crates/schematools/src/codegen/jsonschema/mod.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::large_enum_variant)]
 
-use std::collections::HashMap;
-use std::collections::BTreeMap;
 use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 use serde::{ser::SerializeStruct, Serialize};
@@ -31,6 +30,8 @@ pub struct ModelContainer {
     formats: Vec<String>,
     models: Vec<types::Model>,
     mapping: HashMap<String, u32>,
+    by_name: HashMap<String, u32>,
+    by_hash: HashMap<u64, Vec<u32>>,
     any: types::Model,
 }
 
@@ -54,13 +55,14 @@ impl Default for ModelContainer {
             formats: vec![],
             models: vec![],
             mapping: HashMap::new(),
+            by_name: HashMap::new(),
+            by_hash: HashMap::new(),
             any: types::Model::new(types::ModelType::AnyType(types::AnyType {})),
         }
     }
 }
 
 impl ModelContainer {
-    #[allow(clippy::map_entry)]
     pub fn add(
         &mut self,
         scope: &mut SchemaScope,
@@ -72,50 +74,58 @@ impl ModelContainer {
         }
 
         let key = scope.path();
-        if self.mapping.contains_key(&key) {
-            let id = self.mapping.get(&key).unwrap();
-            let model = self.models.get(*id as usize).unwrap();
+        if let Some(&id) = self.mapping.get(&key) {
+            self.models[id as usize].add_spaces(scope);
+            return (Some(id), &self.models[id as usize]);
+        }
 
-            (Some(*id), model)
-        } else if let Some(id) = self.models.iter().position(|s| s.is_like(&model)) {
-            let id = id as u32;
-
-            self.models
-                .get_mut(id as usize)
-                .unwrap()
-                .add_spaces(scope);
-            self.mapping.insert(key, id);
-
-            let model = self.models.get(id as usize).unwrap();
-
-            (Some(id), model)
-        } else {
-            let name = model.name().unwrap();
-
-            if self.models.iter().any(|c| c.name().unwrap() == name) {
-                let new_name = tools::bump_suffix_number(name);
-                log::warn!(
-                    "{}: absolute: {}, conflict, renaming to: {}",
-                    scope,
-                    key,
-                    new_name
-                );
-
-                self.add(scope, model.rename(new_name))
-            } else if let Some(index) = self.mapping.get(&key) {
-                (Some(*index), self.models.get(*index as usize).unwrap())
-            } else {
-                self.mapping.insert(key, self.models.len() as u32);
-                self.models.push(model);
-
-                let id = self.models.len() - 1;
-                let model = self.models.get(id).unwrap();
-                (Some(id as u32), model)
+        if let Some(hash) = model.attributes.schema_hash {
+            if let Some(candidates) = self.by_hash.get(&hash) {
+                if let Some(&id) = candidates
+                    .iter()
+                    .find(|&&id| self.models[id as usize].is_like(&model))
+                {
+                    self.models[id as usize].add_spaces(scope);
+                    self.mapping.insert(key, id);
+                    return (Some(id), &self.models[id as usize]);
+                }
             }
         }
+
+        let name = model.name().unwrap();
+
+        if self.by_name.contains_key(name) {
+            let new_name = tools::bump_suffix_number(name);
+            log::warn!(
+                "{}: absolute: {}, conflict, renaming to: {}",
+                scope,
+                key,
+                new_name
+            );
+
+            return self.add(scope, model.rename(new_name));
+        }
+
+        let id = self.models.len() as u32;
+        self.mapping.insert(key, id);
+        self.models.push(model);
+        let name = self.models[id as usize].name().unwrap();
+        self.by_name.insert(name.to_string(), id);
+        if let Some(hash) = self.models[id as usize].attributes.schema_hash {
+            self.by_hash.entry(hash).or_default().push(id);
+        }
+
+        (Some(id), &self.models[id as usize])
     }
 
-    pub fn exists(&mut self, model: &types::Model) -> bool {
+    pub fn exists(&self, model: &types::Model) -> bool {
+        if let Some(hash) = model.attributes.schema_hash {
+            if let Some(candidates) = self.by_hash.get(&hash) {
+                return candidates
+                    .iter()
+                    .any(|&id| self.models[id as usize].is_like(model));
+            }
+        }
         self.models.iter().any(|s| s.is_like(model))
     }
 
@@ -128,6 +138,8 @@ impl ModelContainer {
     pub fn retain(&mut self, mut f: impl FnMut(&types::Model) -> bool) {
         self.models.retain(|m| f(m));
         self.mapping.clear();
+        self.by_name.clear();
+        self.by_hash.clear();
     }
 
     pub fn resolve(&mut self, scope: &mut SchemaScope) -> Option<&types::Model> {
@@ -370,30 +382,47 @@ pub fn extract_type(
     })
 }
 
-
-fn schema_hash(node: &Value) -> u64 {
-    let normalized = normalize_schema(node);
+fn schema_hash(schema: &Map<String, Value>) -> u64 {
     let mut hasher = DefaultHasher::new();
-    serde_json::to_vec(&normalized)
-        .expect("failed to serialize schema")
-        .hash(&mut hasher);
+    hash_schema_map(schema, &mut hasher);
     hasher.finish()
 }
 
-fn normalize_schema(node: &Value) -> Value {
+fn hash_schema_map(map: &Map<String, Value>, state: &mut DefaultHasher) {
+    "object".hash(state);
+    let mut entries: Vec<(&String, &Value)> = map.iter().collect();
+    entries.retain(|(k, _)| *k != "title" && *k != "description");
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    entries.len().hash(state);
+    for (k, v) in entries {
+        k.hash(state);
+        hash_schema_value(v, state);
+    }
+}
+
+fn hash_schema_value(node: &Value, state: &mut DefaultHasher) {
     match node {
-        Value::Object(map) => {
-            let mut sorted: BTreeMap<String, Value> = BTreeMap::new();
-            for (key, value) in map.iter() {
-                if key == "title" || key == "description" {
-                    continue;
-                }
-                sorted.insert(key.clone(), normalize_schema(value));
-            }
-            Value::Object(sorted.into_iter().collect())
+        Value::Null => "null".hash(state),
+        Value::Bool(b) => {
+            "bool".hash(state);
+            b.hash(state);
         }
-        Value::Array(arr) => Value::Array(arr.iter().map(normalize_schema).collect()),
-        other => other.clone(),
+        Value::Number(n) => {
+            "number".hash(state);
+            n.to_string().hash(state);
+        }
+        Value::String(s) => {
+            "string".hash(state);
+            s.hash(state);
+        }
+        Value::Array(a) => {
+            "array".hash(state);
+            a.len().hash(state);
+            for v in a {
+                hash_schema_value(v, state);
+            }
+        }
+        Value::Object(o) => hash_schema_map(o, state),
     }
 }
 fn add_validation_and_nullable(
@@ -405,7 +434,7 @@ fn add_validation_and_nullable(
     let hash = if let Some(hash) = model.attributes.schema_hash {
         hash
     } else {
-        schema_hash(&Value::Object(schema.clone()))
+        schema_hash(schema)
     };
 
     if model.attributes.validation.is_some() {

--- a/crates/schematools/src/codegen/jsonschema/mod.rs
+++ b/crates/schematools/src/codegen/jsonschema/mod.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::large_enum_variant)]
 
 use std::collections::HashMap;
+use std::collections::BTreeMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 use serde::{ser::SerializeStruct, Serialize};
 use serde_json::{Map, Value};
@@ -74,14 +77,18 @@ impl ModelContainer {
             let model = self.models.get(*id as usize).unwrap();
 
             (Some(*id), model)
-        } else if self.exists(&model) {
-            let id = self
-                .models
-                .iter()
-                .position(|s| (*s).is_like(&model))
-                .unwrap();
-            let model = self.models.get(id).unwrap();
-            (Some(id as u32), model)
+        } else if let Some(id) = self.models.iter().position(|s| s.is_like(&model)) {
+            let id = id as u32;
+
+            self.models
+                .get_mut(id as usize)
+                .unwrap()
+                .add_spaces(scope);
+            self.mapping.insert(key, id);
+
+            let model = self.models.get(id as usize).unwrap();
+
+            (Some(id), model)
         } else {
             let name = model.name().unwrap();
 
@@ -363,13 +370,47 @@ pub fn extract_type(
     })
 }
 
+
+fn schema_hash(node: &Value) -> u64 {
+    let normalized = normalize_schema(node);
+    let mut hasher = DefaultHasher::new();
+    serde_json::to_vec(&normalized)
+        .expect("failed to serialize schema")
+        .hash(&mut hasher);
+    hasher.finish()
+}
+
+fn normalize_schema(node: &Value) -> Value {
+    match node {
+        Value::Object(map) => {
+            let mut sorted: BTreeMap<String, Value> = BTreeMap::new();
+            for (key, value) in map.iter() {
+                if key == "title" || key == "description" {
+                    continue;
+                }
+                sorted.insert(key.clone(), normalize_schema(value));
+            }
+            Value::Object(sorted.into_iter().collect())
+        }
+        Value::Array(arr) => Value::Array(arr.iter().map(normalize_schema).collect()),
+        other => other.clone(),
+    }
+}
 fn add_validation_and_nullable(
     model: types::Model,
     schema: &Map<String, Value>,
     mcontainer: &mut ModelContainer,
     keep_schema: bool,
 ) -> types::Model {
+    let hash = if let Some(hash) = model.attributes.schema_hash {
+        hash
+    } else {
+        schema_hash(&Value::Object(schema.clone()))
+    };
+
     if model.attributes.validation.is_some() {
+        let mut model = model;
+        model.attributes.schema_hash = Some(hash);
         return model;
     }
 
@@ -454,6 +495,7 @@ fn add_validation_and_nullable(
         } else {
             None
         },
+        schema_hash: Some(hash),
         ..types::Attributes::default()
     };
 

--- a/crates/schematools/src/codegen/jsonschema/mod.rs
+++ b/crates/schematools/src/codegen/jsonschema/mod.rs
@@ -112,6 +112,17 @@ impl ModelContainer {
         self.models.iter().any(|s| s.is_like(model))
     }
 
+    pub fn models(&self) -> &[types::Model] {
+        &self.models
+    }
+
+    /// Remove models matching the predicate. The internal path mapping is cleared because
+    /// indices are no longer valid after the filter.
+    pub fn retain(&mut self, mut f: impl FnMut(&types::Model) -> bool) {
+        self.models.retain(|m| f(m));
+        self.mapping.clear();
+    }
+
     pub fn resolve(&mut self, scope: &mut SchemaScope) -> Option<&types::Model> {
         if let Some(index) = self.mapping.get(&scope.path()) {
             let ids = {

--- a/crates/schematools/src/codegen/jsonschema/mod.rs
+++ b/crates/schematools/src/codegen/jsonschema/mod.rs
@@ -193,6 +193,7 @@ pub struct JsonSchemaExtractOptions {
     pub nested_arrays_as_models: bool,
     pub optional_and_nullable_as_models: bool,
     pub base_name: Option<String>,
+    pub merge_similar_models: bool,
     pub allow_list: bool,
     pub keep_schema: tools::Filter,
 }
@@ -371,6 +372,7 @@ pub fn extract_type(
                     schema,
                     container,
                     options.keep_schema.check(node, false),
+                    options.merge_similar_models,
                 ))
             }
             _ => {
@@ -430,16 +432,22 @@ fn add_validation_and_nullable(
     schema: &Map<String, Value>,
     mcontainer: &mut ModelContainer,
     keep_schema: bool,
+    merge_similar_models: bool,
 ) -> types::Model {
-    let hash = if let Some(hash) = model.attributes.schema_hash {
-        hash
+    let hash = if merge_similar_models {
+        Some(
+            model
+                .attributes
+                .schema_hash
+                .unwrap_or_else(|| schema_hash(schema)),
+        )
     } else {
-        schema_hash(schema)
+        None
     };
 
     if model.attributes.validation.is_some() {
         let mut model = model;
-        model.attributes.schema_hash = Some(hash);
+        model.attributes.schema_hash = hash;
         return model;
     }
 
@@ -524,7 +532,7 @@ fn add_validation_and_nullable(
         } else {
             None
         },
-        schema_hash: Some(hash),
+        schema_hash: hash,
         ..types::Attributes::default()
     };
 
@@ -744,7 +752,10 @@ mod tests {
             }
         }));
 
-        let options = JsonSchemaExtractOptions::default();
+        let options = JsonSchemaExtractOptions {
+            merge_similar_models: true,
+            ..Default::default()
+        };
 
         let client = reqwest::blocking::Client::new();
         let result = extract(&schema, &SchemaStorage::new(&schema, &client), options);
@@ -754,27 +765,20 @@ mod tests {
         let container = result.unwrap();
         let value = serde_json::to_value(container).unwrap();
 
-        assert!(!value
-            .pointer("/models/1/object/properties/0/nullable")
-            .map(|v| v.as_bool().unwrap())
-            .unwrap());
-        assert_eq!(
-            value
-                .pointer("/models/1/object/properties/0/model/name")
-                .map(|v| v.as_str().unwrap())
-                .unwrap(),
-            "Testing"
-        );
-        assert!(value
-            .pointer("/models/1/object/properties/1/nullable")
-            .map(|v| v.as_bool().unwrap())
-            .unwrap());
-        assert_eq!(
-            value
-                .pointer("/models/1/object/properties/1/model/name")
-                .map(|v| v.as_str().unwrap())
-                .unwrap(),
-            "Testing"
-        );
+        let root = value["models"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["object"]["name"].as_str() == Some("MySecretName"))
+            .unwrap();
+
+        let properties = root["object"]["properties"].as_array().unwrap();
+        assert_eq!(properties.len(), 2);
+
+        assert!(!properties[0]["nullable"].as_bool().unwrap());
+        assert_eq!(properties[0]["model"]["name"].as_str().unwrap(), "Testing");
+
+        assert!(properties[1]["nullable"].as_bool().unwrap());
+        assert_eq!(properties[1]["model"]["name"].as_str().unwrap(), "Testing");
     }
 }

--- a/crates/schematools/src/codegen/jsonschema/types.rs
+++ b/crates/schematools/src/codegen/jsonschema/types.rs
@@ -26,6 +26,10 @@ impl Model {
     }
 
     pub fn is_like(&self, other: &Model) -> bool {
+        if let (Some(a), Some(b)) = (self.attributes.schema_hash, other.attributes.schema_hash) {
+            return a == b;
+        }
+
         self.inner == other.inner && self.spaces == other.spaces
     }
 
@@ -226,7 +230,7 @@ pub struct NullableOptionalWrapperType {
     pub model: FlatModel,
 }
 
-#[derive(Debug, Serialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Serialize, Clone, Eq)]
 pub struct Attributes {
     #[serde(rename = "description")]
     pub description: Option<String>,
@@ -251,6 +255,21 @@ pub struct Attributes {
 
     #[serde(rename = "x")]
     pub x: std::collections::HashMap<String, Value>,
+
+    #[serde(skip)]
+    pub schema_hash: Option<u64>,
+}
+
+impl PartialEq for Attributes {
+    fn eq(&self, other: &Self) -> bool {
+        self.default == other.default
+            && self.nullable == other.nullable
+            && self.required == other.required
+            && self.reference == other.reference
+            && self.validation == other.validation
+            && self.schema == other.schema
+            && self.x == other.x
+    }
 }
 
 impl Model {
@@ -571,6 +590,7 @@ impl Default for Attributes {
             reference: false,
             schema: None,
             x: std::collections::HashMap::new(),
+            schema_hash: None,
         }
     }
 }

--- a/crates/schematools/src/codegen/openapi/endpoint.rs
+++ b/crates/schematools/src/codegen/openapi/endpoint.rs
@@ -32,6 +32,10 @@ impl Endpoint {
     pub fn get_tags(&self) -> &Vec<String> {
         &self.tags
     }
+
+    pub fn operation(&self) -> &str {
+        &self.operation
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/schematools/src/codegen/openapi/mod.rs
+++ b/crates/schematools/src/codegen/openapi/mod.rs
@@ -13,6 +13,7 @@ pub mod requestbody;
 pub mod responses;
 pub mod security;
 
+#[derive(Default)]
 pub struct OpenapiExtractOptions {
     pub wrappers: bool,
     pub nested_arrays_as_models: bool,
@@ -26,20 +27,6 @@ pub struct OpenapiExtractOptions {
     pub only_endpoints: Vec<String>,
     /// Remove models that are not referenced by any kept endpoint.
     pub skip_unused_models: bool,
-}
-
-impl Default for OpenapiExtractOptions {
-    fn default() -> Self {
-        Self {
-            wrappers: false,
-            nested_arrays_as_models: false,
-            optional_and_nullable_as_models: false,
-            keep_schema: tools::Filter::default(),
-            skip_endpoints: vec![],
-            only_endpoints: vec![],
-            skip_unused_models: false,
-        }
-    }
 }
 #[derive(Default)]
 pub struct EndpointContainer {
@@ -295,7 +282,7 @@ pub fn extract(
                 )?;
 
                 for endpoint in endpoints.into_iter() {
-                    tags.append(&mut endpoint.get_tags().clone());
+                    tags.extend(endpoint.get_tags().iter().cloned());
                     econtainer.add(endpoint);
                 }
             }
@@ -304,9 +291,7 @@ pub fn extract(
         },
     )?;
 
-    let filtering = !skip_endpoints.is_empty()
-        || !only_endpoints.is_empty()
-        || skip_unused_models;
+    let filtering = !skip_endpoints.is_empty() || !only_endpoints.is_empty() || skip_unused_models;
 
     if filtering {
         let skip: std::collections::HashSet<&str> =
@@ -323,28 +308,28 @@ pub fn extract(
             econtainer.endpoints.iter().map(|e| e.operation()).collect();
 
         mcontainer.retain(|m| {
-            let ops: Vec<&str> = m
-                .spaces
-                .list
-                .iter()
-                .filter_map(|s| match s {
-                    crate::scope::Space::Operation(o) => Some(o.as_str()),
-                    _ => None,
-                })
-                .collect();
+            let mut ops = m.spaces.list.iter().filter_map(|s| match s {
+                crate::scope::Space::Operation(o) => Some(o.as_str()),
+                _ => None,
+            });
 
-            if ops.is_empty() {
+            let first = ops.next();
+            if first.is_none() {
                 return !skip_unused_models;
             }
 
-            ops.iter().any(|o| kept.contains(o))
+            std::iter::once(first.unwrap())
+                .chain(ops)
+                .any(|o| kept.contains(o))
         });
 
-        tags = econtainer
-            .endpoints
-            .iter()
-            .flat_map(|e| e.get_tags().clone())
-            .collect();
+        tags.clear();
+        tags.extend(
+            econtainer
+                .endpoints
+                .iter()
+                .flat_map(|e| e.get_tags().iter().cloned()),
+        );
         tags.sort();
         tags.dedup();
     }
@@ -592,7 +577,10 @@ mod tests {
 
         assert_eq!(openapi.endpoints.len(), 1);
         let value = serde_json::to_value(&openapi).unwrap();
-        assert_eq!(value["endpoints"][0]["operation"].as_str().unwrap(), "createPet");
+        assert_eq!(
+            value["endpoints"][0]["operation"].as_str().unwrap(),
+            "createPet"
+        );
 
         let names = model_names(&openapi);
         assert!(names.contains(&"Pet".to_string()));
@@ -695,12 +683,7 @@ mod tests {
 
         let client = Client::new();
         let storage = SchemaStorage::new(&schema, &client);
-        let openapi = super::extract(
-            &schema,
-            &storage,
-            OpenapiExtractOptions::default(),
-        )
-        .unwrap();
+        let openapi = super::extract(&schema, &storage, OpenapiExtractOptions::default()).unwrap();
 
         let names = model_names(&openapi);
         assert!(
@@ -839,16 +822,15 @@ mod tests {
 
         let client = Client::new();
         let storage = SchemaStorage::new(&schema, &client);
-        let openapi = super::extract(
-            &schema,
-            &storage,
-            OpenapiExtractOptions::default(),
-        )
-        .unwrap();
+        let openapi = super::extract(&schema, &storage, OpenapiExtractOptions::default()).unwrap();
 
         let value = serde_json::to_value(&openapi).unwrap();
         let models = value["models"]["models"].as_array().unwrap();
-        assert_eq!(models.len(), 1, "identical untitled inline models should merge");
+        assert_eq!(
+            models.len(),
+            1,
+            "identical untitled inline models should merge"
+        );
 
         let ops: Vec<_> = models[0]["spaces"]
             .as_array()

--- a/crates/schematools/src/codegen/openapi/mod.rs
+++ b/crates/schematools/src/codegen/openapi/mod.rs
@@ -18,6 +18,28 @@ pub struct OpenapiExtractOptions {
     pub nested_arrays_as_models: bool,
     pub optional_and_nullable_as_models: bool,
     pub keep_schema: tools::Filter,
+    /// Operation ids of endpoints that should be dropped. Models that are only
+    /// referenced by dropped endpoints are also removed from the output.
+    pub skip_endpoints: Vec<String>,
+    /// Only these operation ids are kept. All other endpoints and models tied
+    /// exclusively to them are removed.
+    pub only_endpoints: Vec<String>,
+    /// Remove models that are not referenced by any kept endpoint.
+    pub skip_unused_models: bool,
+}
+
+impl Default for OpenapiExtractOptions {
+    fn default() -> Self {
+        Self {
+            wrappers: false,
+            nested_arrays_as_models: false,
+            optional_and_nullable_as_models: false,
+            keep_schema: tools::Filter::default(),
+            skip_endpoints: vec![],
+            only_endpoints: vec![],
+            skip_unused_models: false,
+        }
+    }
 }
 #[derive(Default)]
 pub struct EndpointContainer {
@@ -130,9 +152,20 @@ pub fn extract(
 
     let root = schema.get_body();
     let resolver = &SchemaResolver::new(schema, storage);
+
+    let OpenapiExtractOptions {
+        wrappers: _,
+        nested_arrays_as_models: _,
+        optional_and_nullable_as_models,
+        keep_schema,
+        skip_endpoints,
+        only_endpoints,
+        skip_unused_models,
+    } = options;
+
     let options = &JsonSchemaExtractOptions {
-        optional_and_nullable_as_models: options.optional_and_nullable_as_models,
-        keep_schema: options.keep_schema,
+        optional_and_nullable_as_models,
+        keep_schema,
         ..Default::default()
     };
 
@@ -271,6 +304,51 @@ pub fn extract(
         },
     )?;
 
+    let filtering = !skip_endpoints.is_empty()
+        || !only_endpoints.is_empty()
+        || skip_unused_models;
+
+    if filtering {
+        let skip: std::collections::HashSet<&str> =
+            skip_endpoints.iter().map(|s| s.as_str()).collect();
+        let only: std::collections::HashSet<&str> =
+            only_endpoints.iter().map(|s| s.as_str()).collect();
+
+        econtainer.endpoints.retain(|e| {
+            let op = e.operation();
+            !skip.contains(op) && (only.is_empty() || only.contains(op))
+        });
+
+        let kept: std::collections::HashSet<&str> =
+            econtainer.endpoints.iter().map(|e| e.operation()).collect();
+
+        mcontainer.retain(|m| {
+            let ops: Vec<&str> = m
+                .spaces
+                .list
+                .iter()
+                .filter_map(|s| match s {
+                    crate::scope::Space::Operation(o) => Some(o.as_str()),
+                    _ => None,
+                })
+                .collect();
+
+            if ops.is_empty() {
+                return !skip_unused_models;
+            }
+
+            ops.iter().any(|o| kept.contains(o))
+        });
+
+        tags = econtainer
+            .endpoints
+            .iter()
+            .flat_map(|e| e.get_tags().clone())
+            .collect();
+        tags.sort();
+        tags.dedup();
+    }
+
     tags.sort();
     tags.dedup();
 
@@ -352,5 +430,205 @@ impl Openapi {
         });
 
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{schema::Schema, storage::SchemaStorage, Client};
+    use serde_json::json;
+
+    fn test_schema() -> Schema {
+        Schema::from_json(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test", "version": "1.0.0" },
+            "components": {
+                "schemas": {
+                    "Pet": {
+                        "type": "object",
+                        "title": "Pet",
+                        "properties": { "id": { "type": "integer" } }
+                    },
+                    "PetInput": {
+                        "type": "object",
+                        "title": "PetInput",
+                        "properties": { "name": { "type": "string" } }
+                    },
+                    "Unused": {
+                        "type": "object",
+                        "title": "Unused",
+                        "properties": { "x": { "type": "string" } }
+                    }
+                }
+            },
+            "paths": {
+                "/pets": {
+                    "get": {
+                        "operationId": "listPets",
+                        "responses": {
+                            "200": {
+                                "description": "ok",
+                                "content": {
+                                    "application/json": {
+                                        "schema": { "$ref": "#/components/schemas/Pet" }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "post": {
+                        "operationId": "createPet",
+                        "requestBody": {
+                            "required": true,
+                            "content": {
+                                "application/json": {
+                                    "schema": { "$ref": "#/components/schemas/PetInput" }
+                                }
+                            }
+                        },
+                        "responses": {
+                            "201": {
+                                "description": "created",
+                                "content": {
+                                    "application/json": {
+                                        "schema": { "$ref": "#/components/schemas/Pet" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+    }
+
+    fn extract(options: OpenapiExtractOptions) -> Openapi {
+        let schema = test_schema();
+        let client = Client::new();
+        let storage = SchemaStorage::new(&schema, &client);
+
+        super::extract(&schema, &storage, options).unwrap()
+    }
+
+    fn model_names(openapi: &Openapi) -> Vec<String> {
+        openapi
+            .models
+            .models()
+            .iter()
+            .map(|m| m.name().unwrap_or_default().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn test_no_skip_endpoints() {
+        let openapi = extract(OpenapiExtractOptions::default());
+
+        let value = serde_json::to_value(&openapi).unwrap();
+        let endpoints: Vec<_> = value["endpoints"].as_array().unwrap().clone();
+
+        assert_eq!(endpoints.len(), 2);
+        let operations: Vec<_> = endpoints
+            .iter()
+            .map(|e| e["operation"].as_str().unwrap())
+            .collect();
+        assert!(operations.contains(&"listPets"));
+        assert!(operations.contains(&"createPet"));
+
+        let names = model_names(&openapi);
+        assert!(names.contains(&"Pet".to_string()));
+        assert!(names.contains(&"PetInput".to_string()));
+        assert!(names.contains(&"Unused".to_string()));
+    }
+
+    #[test]
+    fn test_skip_endpoint_removes_only_related_models() {
+        let openapi = extract(OpenapiExtractOptions {
+            skip_endpoints: vec!["listPets".to_string()],
+            ..Default::default()
+        });
+
+        let value = serde_json::to_value(&openapi).unwrap();
+        let endpoints: Vec<_> = value["endpoints"].as_array().unwrap().clone();
+
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0]["operation"].as_str().unwrap(), "createPet");
+
+        let names = model_names(&openapi);
+        assert!(
+            names.contains(&"Pet".to_string()),
+            "Pet is also used by createPet, so it must stay"
+        );
+        assert!(
+            names.contains(&"PetInput".to_string()),
+            "PetInput is used by createPet, so it must stay"
+        );
+        assert!(
+            names.contains(&"Unused".to_string()),
+            "Unused is not tied to any endpoint, so it must stay"
+        );
+    }
+
+    #[test]
+    fn test_skip_all_endpoints_keeps_unused_models() {
+        let openapi = extract(OpenapiExtractOptions {
+            skip_endpoints: vec!["listPets".to_string(), "createPet".to_string()],
+            ..Default::default()
+        });
+
+        assert!(openapi.endpoints.is_empty());
+        let names = model_names(&openapi);
+        assert!(names.contains(&"Unused".to_string()));
+        assert!(!names.contains(&"Pet".to_string()));
+        assert!(!names.contains(&"PetInput".to_string()));
+    }
+
+    #[test]
+    fn test_only_endpoint_keeps_related_models_and_drops_others() {
+        let openapi = extract(OpenapiExtractOptions {
+            only_endpoints: vec!["createPet".to_string()],
+            ..Default::default()
+        });
+
+        assert_eq!(openapi.endpoints.len(), 1);
+        let value = serde_json::to_value(&openapi).unwrap();
+        assert_eq!(value["endpoints"][0]["operation"].as_str().unwrap(), "createPet");
+
+        let names = model_names(&openapi);
+        assert!(names.contains(&"Pet".to_string()));
+        assert!(names.contains(&"PetInput".to_string()));
+        assert!(
+            names.contains(&"Unused".to_string()),
+            "Unused is not tied to any endpoint, so it stays by default"
+        );
+    }
+
+    #[test]
+    fn test_only_endpoint_with_skip_unused_removes_unused_models() {
+        let openapi = extract(OpenapiExtractOptions {
+            only_endpoints: vec!["listPets".to_string()],
+            skip_unused_models: true,
+            ..Default::default()
+        });
+
+        assert_eq!(openapi.endpoints.len(), 1);
+        let names = model_names(&openapi);
+        assert!(names.contains(&"Pet".to_string()));
+        assert!(!names.contains(&"PetInput".to_string()));
+        assert!(!names.contains(&"Unused".to_string()));
+    }
+
+    #[test]
+    fn test_skip_unused_models_removes_only_unused() {
+        let openapi = extract(OpenapiExtractOptions {
+            skip_unused_models: true,
+            ..Default::default()
+        });
+
+        assert_eq!(openapi.endpoints.len(), 2);
+        let names = model_names(&openapi);
+        assert!(names.contains(&"Pet".to_string()));
+        assert!(names.contains(&"PetInput".to_string()));
+        assert!(!names.contains(&"Unused".to_string()));
     }
 }

--- a/crates/schematools/src/codegen/openapi/mod.rs
+++ b/crates/schematools/src/codegen/openapi/mod.rs
@@ -27,6 +27,8 @@ pub struct OpenapiExtractOptions {
     pub only_endpoints: Vec<String>,
     /// Remove models that are not referenced by any kept endpoint.
     pub skip_unused_models: bool,
+    /// Merge models with the same structure ignoring title and description.
+    pub merge_similar_models: bool,
 }
 #[derive(Default)]
 pub struct EndpointContainer {
@@ -148,10 +150,12 @@ pub fn extract(
         skip_endpoints,
         only_endpoints,
         skip_unused_models,
+        merge_similar_models,
     } = options;
 
     let options = &JsonSchemaExtractOptions {
         optional_and_nullable_as_models,
+        merge_similar_models,
         keep_schema,
         ..Default::default()
     };
@@ -421,8 +425,11 @@ impl Openapi {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{schema::Schema, storage::SchemaStorage, Client};
+    use crate::{
+        process::dereference::Dereferencer, schema::Schema, storage::SchemaStorage, Client,
+    };
     use serde_json::json;
+    use url::Url;
 
     fn test_schema() -> Schema {
         Schema::from_json(json!({
@@ -683,7 +690,15 @@ mod tests {
 
         let client = Client::new();
         let storage = SchemaStorage::new(&schema, &client);
-        let openapi = super::extract(&schema, &storage, OpenapiExtractOptions::default()).unwrap();
+        let openapi = super::extract(
+            &schema,
+            &storage,
+            OpenapiExtractOptions {
+                merge_similar_models: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         let names = model_names(&openapi);
         assert!(
@@ -763,6 +778,7 @@ mod tests {
             &storage,
             OpenapiExtractOptions {
                 skip_endpoints: vec!["getFoo".to_string()],
+                merge_similar_models: true,
                 ..Default::default()
             },
         )
@@ -822,7 +838,15 @@ mod tests {
 
         let client = Client::new();
         let storage = SchemaStorage::new(&schema, &client);
-        let openapi = super::extract(&schema, &storage, OpenapiExtractOptions::default()).unwrap();
+        let openapi = super::extract(
+            &schema,
+            &storage,
+            OpenapiExtractOptions {
+                merge_similar_models: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         let value = serde_json::to_value(&openapi).unwrap();
         let models = value["models"]["models"].as_array().unwrap();
@@ -846,10 +870,147 @@ mod tests {
             &storage,
             OpenapiExtractOptions {
                 skip_endpoints: vec!["getBar".to_string()],
+                merge_similar_models: true,
                 ..Default::default()
             },
         )
         .unwrap();
         assert_eq!(only_foo.models.models().len(), 1);
+    }
+
+    #[test]
+    fn test_similar_inline_models_are_not_merged_without_flag() {
+        let schema = Schema::from_json(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Inline", "version": "1.0.0" },
+            "paths": {
+                "/foo": {
+                    "get": {
+                        "operationId": "getFoo",
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "title": "InlineUser",
+                                            "description": "first description",
+                                            "properties": {
+                                                "id": { "type": "integer" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "/bar": {
+                    "get": {
+                        "operationId": "getBar",
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "title": "InlineUserResponse",
+                                            "description": "different description",
+                                            "properties": {
+                                                "id": { "type": "integer" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }));
+
+        let client = Client::new();
+        let storage = SchemaStorage::new(&schema, &client);
+        let openapi = super::extract(&schema, &storage, OpenapiExtractOptions::default()).unwrap();
+
+        let names = model_names(&openapi);
+        assert!(
+            names.contains(&"InlineUser".to_string()),
+            "InlineUser should be present"
+        );
+        assert!(
+            names.contains(&"InlineUserResponse".to_string()),
+            "InlineUserResponse should be present"
+        );
+        assert_eq!(
+            names.len(),
+            2,
+            "similar inline models with different titles should not be merged without --merge-similar-models"
+        );
+    }
+
+    #[test]
+    fn test_codegen_extract_merges_similar_models_from_dereferenced_file() {
+        let url = Url::parse(&format!(
+            "file://{}/resources/test/openapi/04-codegen-dedup.yaml",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .unwrap();
+        let mut schema = Schema::load_url(url).unwrap();
+
+        let client = Client::new();
+        let storage = SchemaStorage::new(&schema, &client);
+
+        Dereferencer::options()
+            .with_create_internal_references(true)
+            .with_skip_root_internal_references(true)
+            .process(&mut schema, &storage);
+
+        let without_merge =
+            super::extract(&schema, &storage, OpenapiExtractOptions::default()).unwrap();
+
+        let names = model_names(&without_merge);
+        assert!(
+            names.contains(&"ResourceListData".to_string()),
+            "ResourceListData should be present"
+        );
+        assert!(
+            names.contains(&"ResourceList".to_string()),
+            "ResourceDefinition2 should be present when not merging"
+        );
+        assert!(
+            names.contains(&"ResourceDefinition2".to_string()),
+            "ResourceDefinition2 should be present when not merging"
+        );
+        assert!(
+            names.contains(&"ResourceDefinition".to_string()),
+            "ResourceDefinition2 should be present when not merging"
+        );
+
+        let with_merge = super::extract(
+            &schema,
+            &storage,
+            OpenapiExtractOptions {
+                merge_similar_models: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let names = model_names(&with_merge);
+        assert!(
+            names.contains(&"ResourceListData".to_string()),
+            "ResourceListData should be present after merge"
+        );
+        assert!(
+            names.contains(&"ResourceList".to_string()),
+            "ResourceListData should be present after merge"
+        );
+        assert!(
+            !names.contains(&"ResourceDefinition2".to_string()),
+            "ResourceDefinition2 should be merged into ResourceListData"
+        );
     }
 }

--- a/crates/schematools/src/codegen/openapi/mod.rs
+++ b/crates/schematools/src/codegen/openapi/mod.rs
@@ -631,4 +631,243 @@ mod tests {
         assert!(names.contains(&"PetInput".to_string()));
         assert!(!names.contains(&"Unused".to_string()));
     }
+
+    #[test]
+    fn test_inline_response_models_are_extracted_and_deduplicated() {
+        let schema = Schema::from_json(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Inline", "version": "1.0.0" },
+            "paths": {
+                "/foo": {
+                    "get": {
+                        "operationId": "getFoo",
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "title": "InlineUser",
+                                            "properties": {
+                                                "id": { "type": "integer" },
+                                                "address": {
+                                                    "type": "object",
+                                                    "title": "InlineAddress",
+                                                    "properties": { "city": { "type": "string" } }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "/bar": {
+                    "get": {
+                        "operationId": "getBar",
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "title": "InlineUser",
+                                            "properties": {
+                                                "id": { "type": "integer" },
+                                                "address": {
+                                                    "type": "object",
+                                                    "title": "InlineAddress",
+                                                    "properties": { "city": { "type": "string" } }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }));
+
+        let client = Client::new();
+        let storage = SchemaStorage::new(&schema, &client);
+        let openapi = super::extract(
+            &schema,
+            &storage,
+            OpenapiExtractOptions::default(),
+        )
+        .unwrap();
+
+        let names = model_names(&openapi);
+        assert!(
+            names.iter().filter(|n| **n == "InlineUser").count() == 1,
+            "identical inline models should be deduplicated"
+        );
+        assert!(names.contains(&"InlineAddress".to_string()));
+
+        let value = serde_json::to_value(&openapi).unwrap();
+        let user = value["models"]["models"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["object"]["name"].as_str() == Some("InlineUser"))
+            .unwrap();
+        let ops: Vec<_> = user["spaces"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|s| s["Operation"].as_str())
+            .collect();
+        assert!(ops.contains(&"getFoo"));
+        assert!(ops.contains(&"getBar"));
+    }
+
+    #[test]
+    fn test_skip_endpoint_keeps_deduplicated_inline_model() {
+        let schema = Schema::from_json(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Inline", "version": "1.0.0" },
+            "paths": {
+                "/foo": {
+                    "get": {
+                        "operationId": "getFoo",
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "title": "InlineUser",
+                                            "properties": { "id": { "type": "integer" } }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "/bar": {
+                    "get": {
+                        "operationId": "getBar",
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "title": "InlineUser",
+                                            "properties": { "id": { "type": "integer" } }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }));
+
+        let client = Client::new();
+        let storage = SchemaStorage::new(&schema, &client);
+        let openapi = super::extract(
+            &schema,
+            &storage,
+            OpenapiExtractOptions {
+                skip_endpoints: vec!["getFoo".to_string()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let names = model_names(&openapi);
+        assert!(
+            names.contains(&"InlineUser".to_string()),
+            "InlineUser is still used by getBar, so it must stay"
+        );
+    }
+
+    #[test]
+    fn test_untitled_inline_models_are_deduplicated_and_linked() {
+        let schema = Schema::from_json(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "UntitledInline", "version": "1.0.0" },
+            "paths": {
+                "/foo": {
+                    "get": {
+                        "operationId": "getFoo",
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": { "id": { "type": "integer" } }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "/bar": {
+                    "get": {
+                        "operationId": "getBar",
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": { "id": { "type": "integer" } }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }));
+
+        let client = Client::new();
+        let storage = SchemaStorage::new(&schema, &client);
+        let openapi = super::extract(
+            &schema,
+            &storage,
+            OpenapiExtractOptions::default(),
+        )
+        .unwrap();
+
+        let value = serde_json::to_value(&openapi).unwrap();
+        let models = value["models"]["models"].as_array().unwrap();
+        assert_eq!(models.len(), 1, "identical untitled inline models should merge");
+
+        let ops: Vec<_> = models[0]["spaces"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|s| s["Operation"].as_str())
+            .collect();
+        assert!(ops.contains(&"getFoo"));
+        assert!(ops.contains(&"getBar"));
+
+        let only_foo = super::extract(
+            &schema,
+            &storage,
+            OpenapiExtractOptions {
+                skip_endpoints: vec!["getBar".to_string()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(only_foo.models.models().len(), 1);
+    }
 }


### PR DESCRIPTION
Add options for codegen:
- `--skip-endpoint <operation-id>` - skip an endpoint by `operationId`. Can be repeated. Models referenced only by skipped endpoints are removed from the output.
- `--only-endpoint <operation-id>` - keep only the endpoints with given `operationId`. Can be repeated. All other endpoints and their unique models are removed.
- `--skip-unused-models` - remove models that are not referenced by any kept endpoint.
- `--keep-schema <path>` - keep the original JSON schema in selected nodes so it is available in templates. Can be repeated.
- `--merge-similar-models` - merge models with identical structure ignoring `title` and `description`.

